### PR TITLE
Add missing requests package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
+certifi==2022.6.15
+charset-normalizer==2.1.0
+idna==3.3
 psycopg2==2.9.3
+requests==2.28.1
+urllib3==1.26.10


### PR DESCRIPTION
This PR adds missing package dependencies that are required to run `insert_tables.py`.